### PR TITLE
Add time limit option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea
 _posts
 _site
+Gemfile.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matricks"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 dependencies = [
  "clap 4.2.3",
  "extism",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/src/clargs.rs
+++ b/src/clargs.rs
@@ -37,5 +37,5 @@ pub struct Args {
 
     /// Maximum time (in seconds) that a single plugin can run before moving on to the next one. No time limit by default.
     #[arg(short, long)]
-    pub time_limit: Option<u32>,
+    pub time_limit: Option<u64>,
 }

--- a/src/clargs.rs
+++ b/src/clargs.rs
@@ -34,4 +34,8 @@ pub struct Args {
     /// Brightness of matrix, from 0-255
     #[arg(short, long, default_value = "255")]
     pub brightness: u8,
+
+    /// Maximum time (in seconds) that a single plugin can run before moving on to the next one. No time limit by default.
+    #[arg(short, long)]
+    pub time_limit: Option<u32>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,10 +160,26 @@ fn main() {
             }
         };
 
+        // mark the time when this plugin started its update loop
+        let plugin_start_time = Instant::now();
+
         // setup the last frame time variable
         let mut last_frame_time = Instant::now();
+
+        // run an update every frame
         'update_loop: loop {
-            // only call the update function if a frame has passes
+            // move on to the next plugin if the plugin time limit has been exceeded
+            match args.time_limit {
+                None => {/* there is no time limit, so do nothing */}
+                Some(time_limit) => {
+                    // move on to the next plugin if this plugin has been running longer than the time limit
+                    if Instant::now() - plugin_start_time > Duration::from_secs(time_limit) {
+                        break 'update_loop
+                    }
+                }
+            }
+
+            // call the update function if a frame has passed
             if (Instant::now() - last_frame_time) >= target_frame_time_ms {
                 // reset the last frame time
                 last_frame_time = Instant::now();


### PR DESCRIPTION
Adds command line option to automatically switch to the next plugin after a set time. By default, plugins run indefinitely. Closes #3.