### PR TITLE
Add plugin loop option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matricks"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "clap 4.2.3",
  "extism",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/src/clargs.rs
+++ b/src/clargs.rs
@@ -20,7 +20,7 @@ pub struct Args {
     pub fps: f32,
 
     /// Directory to write logs
-    #[arg(short, long, default_value = "log")]
+    #[arg(short = 'L', long = "log", default_value = "log")]
     pub log_dir: String,
 
     /// Data line alternates direction between columns or rows
@@ -38,4 +38,8 @@ pub struct Args {
     /// Maximum time (in seconds) that a single plugin can run before moving on to the next one. No time limit by default.
     #[arg(short, long)]
     pub time_limit: Option<u64>,
+
+    /// Loop plugin or set of plugins indefinitely
+    #[arg(short = 'l', long = "loop", default_value = "false")]
+    pub loop_plugins: bool,
 }


### PR DESCRIPTION
Adds command line flag to loop plugins once all plugins have completed. Has the side effect that the plugin directory will now be checked before running the plugins again, allowing for plugins to be added/removed from the watch directory while Matricks is still running.

Closes #2 