### PR TITLE
Remove Simulator

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,16 +336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c044c781163c001b913cd018fc95a628c50d0d2dfea8bca77dad71edb16e37"
-dependencies = [
- "clang-sys",
- "libc",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,7 +343,6 @@ checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -734,12 +723,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "either"
@@ -1182,16 +1165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,20 +1253,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "matricks"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "clap 4.2.3",
  "extism",
  "glob",
  "matricks_plugin",
- "opencv",
  "regex",
  "rs_ws281x",
  "serde",
@@ -1419,41 +1385,6 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-
-[[package]]
-name = "opencv"
-version = "0.79.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585b34725294bd208189414897c19fbc8b3aef4b0639fb44127317a31da35d0c"
-dependencies = [
- "cc",
- "clang",
- "dunce",
- "jobserver",
- "libc",
- "num-traits",
- "once_cell",
- "opencv-binding-generator",
- "pkg-config",
- "semver",
- "shlex",
- "vcpkg",
-]
-
-[[package]]
-name = "opencv-binding-generator"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a90831c40453065b595b935ec56240cd82de52b9d15257fd1f0446ae439950"
-dependencies = [
- "clang",
- "clang-sys",
- "dunce",
- "maplit",
- "once_cell",
- "percent-encoding",
- "regex",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1791,12 +1722,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -2236,12 +2161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2314,24 +2233,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2339,22 +2258,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"
@@ -22,9 +22,4 @@ extism = "0.3.0"
 serde = "1.0.159"
 serde_json = "1.0.95"
 matricks_plugin = "0.1.4"
-
-[target.'cfg(target_arch = "aarch64")'.dependencies]
 rs_ws281x = "0.4.4"
-
-[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
-opencv = "0.79.0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Matricks is a WASM-based extensible LED matrix control tool intended for use on Raspberry Pi devices.
 LED matrix functionality is defined by user-developed plugins, or "tricks", which can be developed in any language that 
 is supported by the [Extism PDK](https://extism.org/docs/category/write-a-plug-in). 
-On non-Raspberry Pi devices, Matricks will simulate a LED matrix and display the simulated matrix state in real time.
+To simulate plugins while you're developing them, check out [Simtricks](https://github.com/wymcg/simtricks)!
 
 See usage details below:
 
@@ -28,38 +28,6 @@ Options:
 ```
 
 ## Installation
-Matricks is installed using Cargo. 
-In order to run a simulated matrix on non-Raspberry Pi machines, 
-OpenCV and supported libraries must be installed before installing Matricks.
-See platform-specific instructions below.
-
-### Raspberry Pi
 - Install Rust and Cargo from [the Rust website](https://rustup.rs)
 - Run `apt install libclang-dev`
 - Run `cargo install matricks`
-
-### Windows
-- Install Rust and Cargo from [the Rust website](https://rustup.rs)
-- Install Chocolatey from [the Chocolatey website](https://chocolatey.org/install)
-- Install vcpkg from the [the vcpkg website](https://vcpkg.io/en/getting-started.html)
-- Run `choco install llvm opencv`
-- Run `vcpkg install llvm opencv4[contrib,nonfree]`
-- Run `cargo install matricks`
-
-### Ubuntu
-- Install Rust and Cargo from [the Rust website](https://rustup.rs)
-- Run `apt install libopencv-dev clang libclang-dev`
-- Run `cargo install matricks`
-
-### Arch Linux
-- Install Rust and Cargo from [the Rust website](https://rustup.rs)
-- Run `pacman -S clang qt5-base opencv`
-- Run `pacman -S vtk glew fmt openmpi`
-- Run `cargo install matricks`
-
-### Mac
-- Install Rust and Cargo from [the Rust website](https://rustup.rs)
-- Run `brew install opencv`
-- Run `cargo install matricks`
-
-Note: for installation on Mac, you will likely also need a C++ compiler and libclang (`brew install llvm`).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Options:
 ```
 
 ## Installation
+- Install 64-bit Raspbian[^1] on your Raspberry Pi[^2].
 - Install Rust and Cargo from [the Rust website](https://rustup.rs)
-- Run `apt install libclang-dev`
+- Run `apt install libclang-dev libssl-dev`
+- Install and configure the [rpi_ws281x library](https://github.com/rpi-ws281x/rpi_ws281x).
 - Run `cargo install matricks`
+
+[^1]: At this time, Matricks can only be installed on 64-bit operating systems.
+[^2]: If you are using a Raspberry Pi with less than 1GB of RAM, compiling directly on the Pi is not recommended.


### PR DESCRIPTION
Removes the simulator. Plugin simulation will be moved to a separate project.

From this PR onward, Matricks is intended only to run on devices that will drive LEDs.