### PR TITLE
Add Rust and JavaScript Example Plugins

### DIFF
--- a/examples/example_js/README.md
+++ b/examples/example_js/README.md
@@ -1,0 +1,9 @@
+# JavaScript Example Trick
+This is a simple example Matricks plugin that will fade from black to white, before halting and sending a log.
+**At this time, the only Mac and Linux are supported for plugin compilation.**
+
+## Build
+- Download the compiler install script with `curl -O https://raw.githubusercontent.com/extism/js-pdk/main/install.sh`
+- Run the installer with `sh install.sh`
+- Navigate to the `example_js` folder and run `extism-js example.js -o example_js.wasm`
+- Run the plugin with [Matricks](https://github.com/wymcg/matricks) (on a Raspberry Pi) or with [Simtricks](https://github.com/wymcg/simtricks) (on other devices).

--- a/examples/example_js/example.js
+++ b/examples/example_js/example.js
@@ -1,0 +1,45 @@
+// Setup global variables
+let mat_config = {};
+let counter = 0;
+
+function setup() {
+    // Populate the matrix configuration
+    mat_config = JSON.parse(Host.inputString());
+}
+
+function update() {
+    // Fill the matrix state
+    let matrix = [];
+    for (let y = 0; y < mat_config.height; y++) {
+        matrix.push([])
+        for (let x = 0; x < mat_config.width; x++) {
+            matrix[y].push([counter, counter, counter, 0]);
+        }
+    }
+
+    // Increment the counter
+    counter++;
+
+
+    if (counter == 255) {
+        // Return the plugin update
+        Host.outputString(JSON.stringify({
+            state: matrix,
+            done: true,
+            log_message: ["Done fading to white!"]
+        }));
+    } else {
+        // Increment the counter
+        counter++;
+
+        // Return the plugin update
+        Host.outputString(JSON.stringify({
+            state: matrix,
+            done: false,
+            log_message: null
+        }));
+    }
+
+}
+
+module.exports = {setup, update}

--- a/examples/example_rust/Cargo.toml
+++ b/examples/example_rust/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "example_rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+extism-pdk = "0.3.3"
+matricks_plugin = "0.1.3"
+serde_json = "1.0.96"
+lazy_static = "1.4.0"

--- a/examples/example_rust/README.md
+++ b/examples/example_rust/README.md
@@ -1,0 +1,7 @@
+# Rust Example Trick
+This is a simple example Matricks plugin that will fade from black to white, before halting and sending a log.
+
+## Build
+- Install the `wasm32-wasi` toolchain by running `rustup target add wasm32-wasi`
+- Navigate to the `example_rust` folder and run `cargo build --release --target wasm32-wasi`
+- Run the plugin with [Matricks](https://github.com/wymcg/matricks) (on a Raspberry Pi) or with [Simtricks](https://github.com/wymcg/simtricks) (on other devices).

--- a/examples/example_rust/src/lib.rs
+++ b/examples/example_rust/src/lib.rs
@@ -1,0 +1,63 @@
+use extism_pdk::*;
+use lazy_static::lazy_static;
+use matricks_plugin::{MatrixConfiguration, PluginUpdate};
+use serde_json::from_str;
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+
+lazy_static! {
+    static ref CONFIG: Arc<Mutex<MatrixConfiguration>> =
+        Arc::new(Mutex::new(MatrixConfiguration::default()));
+    static ref COUNTER: Arc<Mutex<u8>> = Arc::new(Mutex::new(0));
+}
+
+#[plugin_fn]
+pub fn setup(cfg_json: String) -> FnResult<()> {
+    // Set the matrix configuration struct
+    let mut config = CONFIG.lock().unwrap();
+    let config = config.deref_mut();
+    *config = from_str(&*cfg_json)
+        .expect("Unable to deserialize matrix config!");
+
+    Ok(())
+}
+
+#[plugin_fn]
+pub fn update(_: ()) -> FnResult<Json<PluginUpdate>> {
+    // Get the static config object
+    let config = CONFIG.lock().unwrap();
+
+    // Get the static counter
+    let mut counter = COUNTER.lock().unwrap();
+    let counter = counter.deref_mut();
+
+    // Make a 2D vector of all red, with intensity set by the counter value
+    let mut led_state: Vec<Vec<[u8; 4]>> = vec![];
+    for y in 0..config.width {
+        led_state.push(vec![]);
+        for _x in 0..config.height {
+            led_state[y].push([*counter, *counter, *counter, 0]); // BGRA order!
+        }
+    }
+
+    // Increment counter and determine whether to stop providing updates
+    if *counter == 255 {
+        // If the counter is 255, let's stop the plugin and log why
+        Ok(Json(PluginUpdate {
+            state: led_state,
+            done: true,
+            log_message: Some(vec!["Done fading to white!".to_string()]),
+            ..Default::default()
+        }))
+    } else {
+        // If the counter is less than 255, increment the counter
+        *counter += 1;
+
+        Ok(Json(PluginUpdate {
+            state: led_state,
+            done: false,
+            ..Default::default()
+        }))
+    }
+
+}


### PR DESCRIPTION
Adds simple example plugins written in Rust and JavaScript. Both plugins fade from full black to full white before halting and sending a log.