### PR TITLE
Clear LEDs on normal exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "matricks"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "clap 4.2.3",
  "extism",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/src/matrix_control_thread.rs
+++ b/src/matrix_control_thread.rs
@@ -103,4 +103,12 @@ fn matrix_control(
             }
         }
     }
+
+    // When the update channel closes, clear the LEDs
+    let leds = controller.leds_mut(0);
+    for led in leds {
+        *led = [0, 0, 0, 0];
+    }
+    controller.render().expect("Unable to clear screen while quitting!")
+
 }


### PR DESCRIPTION
When Matricks quits normally (all plugins have stopped and the loop flag is not enabled), clear all LEDs.

Closes #10.