### PR TITLE
Remove Magnification Command Line Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,9 +1268,8 @@ dependencies = [
 
 [[package]]
 name = "matricks_plugin"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450889cc5d5570824876437f7a9b3dab383d8d1702ef19f53d7cb3c1f6ac357a"
+version = "0.1.5"
+source = "git+https://github.com/wymcg/matricks_plugin#1fbdfa69fea6912ef074434e83a85e90cc8ea496"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ glob = "0.3.1"
 extism = "0.3.0"
 serde = "1.0.159"
 serde_json = "1.0.95"
-matricks_plugin = "0.1.4"
+matricks_plugin = { git = "https://github.com/wymcg/matricks_plugin" }
 rs_ws281x = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"
@@ -21,5 +21,5 @@ glob = "0.3.1"
 extism = "0.3.0"
 serde = "1.0.159"
 serde_json = "1.0.95"
-matricks_plugin = { git = "https://github.com/wymcg/matricks_plugin" }
+matricks_plugin = "0.1.4"
 rs_ws281x = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Options:
   -f, --fps <FPS>                      Target framerate at which to drive the matrix [default: 30]
   -L, --log <LOG_DIR>                  Directory to write logs [default: log]
   -s, --serpentine                     Data line alternates direction between columns or rows
-  -m, --magnification <MAGNIFICATION>  Magnification of the simulated matrix [default: 10]
   -b, --brightness <BRIGHTNESS>        Brightness of matrix, from 0-255 [default: 255]
   -t, --time-limit <TIME_LIMIT>        Maximum time (in seconds) that a single plugin can run before moving on to the next one. No time limit by default
   -l, --loop                           Loop plugin or set of plugins indefinitely

--- a/src/clargs.rs
+++ b/src/clargs.rs
@@ -27,10 +27,6 @@ pub struct Args {
     #[arg(short, long, default_value = "false")]
     pub serpentine: bool,
 
-    /// Magnification of the simulated matrix
-    #[arg(short, long, default_value = "10")]
-    pub magnification: f32,
-
     /// Brightness of matrix, from 0-255
     #[arg(short, long, default_value = "255")]
     pub brightness: u8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,6 @@ fn main() {
         height: args.height,
         target_fps: args.fps,
         serpentine: args.serpentine,
-        magnification: args.magnification,
         brightness: args.brightness,
         ..Default::default()
     };


### PR DESCRIPTION
Removes the magnification command line argument, which is unnecessary after #14. The `MatrixConfiguration` struct in `matricks_plugin` retains this field because removing it would be a breaking change for plugins developed before the simulator was removed (see wymcg/matricks_plugin#1).

Closes #19.