### PR TITLE
Cross compilation by default

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,6 @@
+[build]
+rustflags = ["-C", "target-feature=+crt-static"]
+target = "aarch64-unknown-linux-gnu"
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "matricks"
-version = "0.2.0-beta.1"
+version = "0.2.0"
 dependencies = [
  "clap 4.2.3",
  "extism",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,12 +26,24 @@ Options:
   -V, --version                        Print version
 ```
 
-## Installation
-- Install 64-bit Raspbian[^1] on your Raspberry Pi[^2].
+## Installation on Raspberry Pi
+- Install 64-bit Raspbian[^1] on your Raspberry Pi[^2]
 - Install Rust and Cargo from [the Rust website](https://rustup.rs)
 - Run `apt install libclang-dev libssl-dev`
 - Install and configure the [rpi_ws281x library](https://github.com/rpi-ws281x/rpi_ws281x).
 - Run `cargo install matricks`
 
-[^1]: At this time, Matricks can only be installed on 64-bit operating systems.
-[^2]: If you are using a Raspberry Pi with less than 1GB of RAM, compiling directly on the Pi is not recommended.
+## Cross-compilation for Raspberry Pi
+- On another device,
+  - Install Rust and Cargo from [the Rust website](https://rustup.rs)
+  - Run `rustup target add aarch64-unknown-linux-gnu`
+  - Build with `cargo build --release`[^3]
+  - Transfer the produced executable to your Raspberry Pi
+- On your Raspberry Pi,
+  - Install 64-bit Raspbian[^1]
+  - Install and configure the [rpi_ws281x library](https://github.com/rpi-ws281x/rpi_ws281x).
+  - Run the executable
+
+[^1]: At this time, Matricks can only be installed and run on 64-bit operating systems.
+[^2]: If you are using a Raspberry Pi with less than 1GB of RAM, installation using this method is not recommended.
+[^3]: No need for a `--target` flag here, Matricks is set up to build for Raspberry Pi by default.


### PR DESCRIPTION
Adds flags in `.cargo/config` that make it so that by default, Matricks is compiled for `aarch64-unknown-linux-gnu`. Also by default, `glibc` will by statically linked to the executable.

This PR also adds instructions to the README describing how to cross-compile the executable, as well as how to use the produced executable on a Raspberry Pi.

Closes #15.