### PR TITLE
Default log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "matricks"
-version = "0.3.0-alpha.0"
+version = "0.3.0-alpha.1"
 dependencies = [
  "clap 4.4.6",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.3.0-alpha.0"
+version = "0.3.0-alpha.1"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,21 @@ mod path_map;
 use crate::clargs::{MatricksArgs, MatricksSubcommand};
 use crate::core::matricks_core;
 
-use std::fs;
+use std::{env, fs};
 use clap::Parser;
 use crate::control::{clear_matrix, make_led_controller};
 
 const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
+const DEFAULT_LOG_LEVEL: &str = "matricks=info";
 
 fn main() {
     // Parse command line arguments
     let args = MatricksArgs::parse();
+
+    // If the user has not setup the logger themselves, set the log level to the default
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", DEFAULT_LOG_LEVEL);
+    }
 
     // Start the logger
     env_logger::init();


### PR DESCRIPTION
If the user has not set a log level using the `RUST_LOG` environment variable, then the logger will default to `RUST_LOG=matricks=info`.