### PR TITLE
Change plugin update return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,28 +1306,18 @@ dependencies = [
 
 [[package]]
 name = "matricks"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 dependencies = [
  "clap 4.4.6",
  "env_logger",
  "extism",
  "glob",
  "log",
- "matricks_plugin",
  "regex",
  "rs_ws281x",
  "serde",
  "serde_json",
  "toml 0.8.1",
-]
-
-[[package]]
-name = "matricks_plugin"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450889cc5d5570824876437f7a9b3dab383d8d1702ef19f53d7cb3c1f6ac357a"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"
@@ -22,7 +22,6 @@ extism = "0.5.2"
 serde = "1.0.188"
 serde_json = "1.0.107"
 toml = "0.8.1"
-matricks_plugin = "0.1.4"
 rs_ws281x = "0.4.4"
 env_logger = "0.10.0"
 log = "0.4.20"


### PR DESCRIPTION
Plugins now return a 2D array of BGRA values as JSON, instead of the custom PluginUpdate struct as JSON. Plugins can signal that they will not provide any further updates by returning null (`None` in Rust).

Closes #51 