### PR TITLE
Remove reference to `matricks_plugin` crate

### DIFF
--- a/02_plugins.md
+++ b/02_plugins.md
@@ -194,10 +194,9 @@ Hopefully, you've been able to get your hands dirty with some Matricks plugin de
 
 - [Matricks GitHub](https://github.com/wymcg/matricks)
 - [Example Plugins](https://github.com/wymcg/matricks/issues/39)
-- [matricks_plugin docs.rs](https://docs.rs/matricks_plugin/latest/matricks_plugin/)
 - [Extism PDK for Rust](https://extism.org/docs/write-a-plugin/rust-pdk/)
 - [Extism PDK for other languages](https://extism.org/docs/category/write-a-plug-in)
 
-If you like this project, contribute on [GitHub](https://github.com/wymcg/matricks/issues)!
+
 
 ---


### PR DESCRIPTION
Remove reference to the `matricks_plugin` crate on the Github Pages site. The `matricks_plugin` crate is no longer needed after v0.3.0