### PR TITLE
Fix infinite loop when the control thread fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "matricks"
-version = "0.3.0-alpha.3"
+version = "0.3.0"
 dependencies = [
  "clap 4.4.6",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.3.0"
+version = "0.3.1-alpha.0"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/src/core.rs
+++ b/src/core.rs
@@ -275,7 +275,7 @@ pub fn matricks_core(config: MatricksConfigArgs) {
                                         Err(e) => {
                                             log::error!("Failed to send state update to matrix control.");
                                             log::debug!("Received the following error while sending new state to matrix controller: {e}");
-                                            log::info!("Quitting Matricks.");
+                                            break 'main_loop;
                                         }
                                     }
                                 }


### PR DESCRIPTION
Matricks would get stuck in an infinite loop attempting to send a new frame to the matrix control thread. This PR adds a missing exit from the main loop to resolve this issue.

Bug discovered by @mnmartinelli.