### PR TITLE
Add missing help text for --allow-host and --map-path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "matricks"
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 dependencies = [
  "clap 4.4.6",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matricks"
-version = "0.3.1-alpha.0"
+version = "0.3.1-alpha.1"
 edition = "2021"
 authors = ["Will McGloughlin <willem.mcg@gmail.com>"]
 license = "MIT"

--- a/src/clargs.rs
+++ b/src/clargs.rs
@@ -89,9 +89,11 @@ pub struct PluginConfigurationArgs {
     #[arg(short = 'l', long = "loop", default_value = MATRICKS_DEFAULT_LOOP)]
     pub loop_plugins: bool,
 
+    /// Allow plugins to access a particular network host
     #[arg(long)]
     pub allow_host: Option<Vec<String>>,
 
+    /// Map a path on the host filesystem to a path on the plugin filesystem. Inputs should be of the form "DEST_PATH>HOST_PATH".
     #[arg(long)]
     pub map_path: Option<Vec<String>>,
 }


### PR DESCRIPTION
This PR adds missing help text for the "allow host" and "map path" options.

Closes #68 